### PR TITLE
Remove "primary monitor" window constraint

### DIFF
--- a/gtktitlebar@velitasali.github.io/helpers.js
+++ b/gtktitlebar@velitasali.github.io/helpers.js
@@ -61,14 +61,14 @@ function isMaximized(win, matchState) {
 
     let flags = Meta.MaximizeFlags;
     let maximized = win.get_maximized();
-    let primaryScreen = win.is_on_primary_monitor();
     let tileMaximized = maximized == flags.HORIZONTAL || maximized == flags.VERTICAL;
     let fullMaximized = maximized == flags.BOTH;
     let bothMaximized = fullMaximized || tileMaximized;
 
     switch (matchState) {
-        case 'both': return primaryScreen && bothMaximized;
-        case 'maximized': return primaryScreen && fullMaximized;
-        case 'tiled': return primaryScreen && tileMaximized;
+        case 'both': return bothMaximized;
+        case 'maximized': return fullMaximized;
+        case 'tiled': return tileMaximized;
     }
 }
+


### PR DESCRIPTION
Thanks for making this extension, I find the window decorations in Gnome a huge waste of space for all the applications I run maximized.

I was wondering if removing decorations only for windows on the primary monitor was a deliberate design choice?

If this just happened to be something that fell out of copy-pasting code, here is a PR to remove this constraint.