### PR TITLE
Add support for Gnome 43 and bump version to 11

### DIFF
--- a/gtktitlebar@velitasali.github.io/metadata.json
+++ b/gtktitlebar@velitasali.github.io/metadata.json
@@ -1,8 +1,8 @@
 {
-  "shell-version": ["40", "41", "42"],
+  "shell-version": ["40", "41", "42", "43"],
   "name": "GTK Title Bar",
   "description": "Remove title bars for non-GTK apps with minimal interference with the default workflow",
-  "version": 10,
+  "version": 11,
   "settings-schema": "org.gnome.shell.extensions.gtktitlebar",
   "gettext-domain": "gtktitlebar",
   "url": "https://github.com/velitasali/gtktitlebar",


### PR DESCRIPTION
Works on Gnome 43, have tested and haven't found any bugs so far